### PR TITLE
Fix compiler error in the Swift example on Xcode 6.1.

### DIFF
--- a/Examples/IndoorLocation SwiftExample/IndoorLocation SwiftExample/MenuViewController.swift
+++ b/Examples/IndoorLocation SwiftExample/IndoorLocation SwiftExample/MenuViewController.swift
@@ -53,7 +53,7 @@ class MenuViewController: UIViewController, AuthorizationViewControllerDelegate 
     @IBAction func loadLocationFromJSON() {
         let bundle = NSBundle.mainBundle()
         let path = bundle.pathForResource("location", ofType: "json")
-        let content = NSString.stringWithContentsOfFile(path!, encoding: NSUTF8StringEncoding, error: nil) as String
+        let content = NSString(contentsOfFile: path!, encoding: NSUTF8StringEncoding, error: nil) as String
         
         let location = ESTLocationBuilder.parseFromJSON(content)
         


### PR DESCRIPTION
'stringWithContentsOfFile(_:encoding:error:)' is unavailable: use object construction 'NSString(contentsOfFile:encoding:error:)'
